### PR TITLE
Fix

### DIFF
--- a/BACKEND/app/crud.py
+++ b/BACKEND/app/crud.py
@@ -1178,7 +1178,7 @@ def get_modified_verses(db: Session, chapter_id: int) -> list:
     """
     Fetch all modified verses for the given chapter.
     """
-    return db.query(Verse).filter(Verse.chapter_id == chapter_id, Verse.modified == True).all()
+    return db.query(Verse).filter(Verse.chapter_id == chapter_id, Verse.modified == True ,Verse.tts == False).all()
 
 
 

--- a/BACKEND/app/router.py
+++ b/BACKEND/app/router.py
@@ -402,7 +402,6 @@ async def add_new_book_zip(
     - project_id: The ID of the project to which the book is added.
     - file: The uploaded ZIP file containing the book structure.
     """
-    temp_extract_path = None
     try:
         # Step 1: Process the ZIP file (Extract, Validate)
         book_data  = await crud.process_book_zip(
@@ -412,6 +411,7 @@ async def add_new_book_zip(
         return crud.save_book_to_project(**book_data, db=db)
     except HTTPException as http_exc:
         logger.error(f"HTTP Exception: {http_exc.detail}")
+        raise
     except Exception as e:
         logger.error(f"Unexpected error: {str(e)}")
         raise HTTPException(status_code=500, detail="An error occurred while adding the book")

--- a/BACKEND/app/router.py
+++ b/BACKEND/app/router.py
@@ -412,15 +412,8 @@ async def add_new_book_zip(
         return crud.save_book_to_project(**book_data, db=db)
     except HTTPException as http_exc:
         logger.error(f"HTTP Exception: {http_exc.detail}")
-         # Cleanup temporary extraction folder
-        if temp_extract_path:
-            shutil.rmtree(temp_extract_path, ignore_errors=True)
-        raise
     except Exception as e:
         logger.error(f"Unexpected error: {str(e)}")
-         # Cleanup temporary extraction folder
-        if temp_extract_path:
-            shutil.rmtree(temp_extract_path, ignore_errors=True)
         raise HTTPException(status_code=500, detail="An error occurred while adding the book")
 
  

--- a/UI/src/components/AudioPlayer.tsx
+++ b/UI/src/components/AudioPlayer.tsx
@@ -4,7 +4,6 @@ import { Slider } from "@/components/ui/slider";
 import {
   PlayIcon,
   PauseIcon,
-  Mic,
   X,
   Volume2,
   VolumeX,

--- a/UI/src/components/ChapterModal.tsx
+++ b/UI/src/components/ChapterModal.tsx
@@ -228,10 +228,6 @@ const ChapterModal: React.FC<ChapterModalProps> = ({
       [chapter.chapter_id]: true,
     }));
 
-    if (currentVerse && verseModifications[currentVerse.verse_id]) {
-      setCurrentVerse(null);
-    }
-
     await handleVerseUpdate();
 
     // Get latest chapter details
@@ -240,7 +236,7 @@ const ChapterModal: React.FC<ChapterModalProps> = ({
     const modifiedVerses =
       sortedVerses
         ?.filter(
-          (verse) => verse.modified || verseModifications[verse.verse_id]
+          (verse) => (verse.modified && !verse.tts) || verseModifications[verse.verse_id]
         )
         .map((verse) => verse.verse_id) || [];
 
@@ -256,6 +252,9 @@ const ChapterModal: React.FC<ChapterModalProps> = ({
       return;
     }
 
+    if (currentVerse && (verseModifications[currentVerse.verse_id] || modifiedVerses.includes(currentVerse.verse_id))) {
+      setCurrentVerse(null);
+    }
     
 
     const resultMsg = await convertToSpeech(projectId, bookName, chapter);

--- a/UI/src/store/useProjectStore.ts
+++ b/UI/src/store/useProjectStore.ts
@@ -139,7 +139,7 @@ interface ChapterDetailsState {
 // Utility function to calculate book status based on chapters
 const calculateBookStatus = (chapters: Chapter[]): string => {
   console.log("chapters for book status", chapters);
-  if (chapters.every(ch => ch.status === "approved")) return "approved";
+  if (chapters.every(ch => ch.status === "approved" || ch.approved)) return "approved";
   if (chapters.every(ch => ["approved", "converted"].includes(ch.status || ""))) return "converted";
   if (chapters.some(ch => ch.status === "converting")) return "converting";
   if (chapters.some(ch => ch.status === "inProgress" || ch.progress === "processing")) return "inProgress";
@@ -816,7 +816,7 @@ export const useChapterDetailsStore = create<ChapterDetailsState>((set) => ({
           const checkModifiedConverted =
             modifiedVerses.length > 0 &&
             modifiedVerses.every((verse) => verse.tts);
-  
+          const checkChapterOnlyModified = modifiedVerses.length >0 && !checkModifiedConverted;
           useProjectDetailsStore.getState().setProject((prevProject) => {
             if (!prevProject) return null;
   
@@ -828,6 +828,7 @@ export const useChapterDetailsStore = create<ChapterDetailsState>((set) => ({
                       ? "approved"
                       : checkModifiedConverted
                       ? "converted"
+                      : checkChapterOnlyModified ? "modified" 
                       : checkTranscribed
                       ? "transcribed"
                       : ch.status;


### PR DESCRIPTION
- Books are not able to upload ,raising invalid folder structure

    When QA tests with an invalid ZIP structure — for example, by giving a book folder name that doesn't match the expected format — the extract_and_validate_zip() function raises an error. Since the temporary folder is only cleaned up in the router and not inside the extraction function itself, the temporary directory (extracted_book) remains.if someone tries to upload another file afterward, the leftover folder causes the same error to be raised again, creating a loop of failed attempts.
