### PR TITLE
Added Chapter wise Convertion

### DIFF
--- a/UI/src/store/useProjectStore.ts
+++ b/UI/src/store/useProjectStore.ts
@@ -11,7 +11,7 @@ interface ProjectDetailsState {
   setProject: (updater: (project: Project | null) => Project | null) => void;
   fetchProjectDetails: (projectId: number) => void;
   clearProjectState: () => void;
-  transcribeBook: (bookId: number, queryClient?: QueryClient) => Promise<void>;
+  transcribeBook: (bookId: number, selectedChapters: any, queryClient?: QueryClient) => Promise<void>;
   archiveProject: (projectId: number, archive: boolean) => Promise<void>;
 }
 
@@ -466,7 +466,7 @@ export const useProjectDetailsStore = create<ProjectDetailsState>(
 
     clearProjectState: () => set({ project: null }),
 
-    transcribeBook: async (bookId: number, queryClient?: QueryClient) => {
+    transcribeBook: async (bookId: number, selectedChapters: Chapter[], queryClient?: QueryClient) => {
       const token = useAuthStore.getState().token;
       const currentProject = get().project;
 
@@ -524,7 +524,8 @@ export const useProjectDetailsStore = create<ProjectDetailsState>(
         };
 
         // Sequential chapter transcription
-        for (const chapter of book.chapters) {
+        // for (const chapter of book.chapters) {  --> removing for now for adding chapter wise convertion
+        for (const chapter of selectedChapters) {
           // Set progress for current chapter
           useTranscriptionTrackingStore
             .getState()


### PR DESCRIPTION
## Issue
Provide an option to transcribe specific chapters rather than the entire book. This would significantly reduce conversion times and improve efficiency. #175 

## Fixes

- Currently, we're preventing full chapter conversions because the app workflow only requires converting one chapter at a time.
- An error message will display if no chapter is selected for conversion.
- Users can select single or multiple books. Clicking a selected chapter will deselect it.
- We're preventing selection of chapters from different books; an error message will appear if attempted.
- Selected books have a background color for better visibility.
- Removed consoles

Error 1
![Image](https://github.com/user-attachments/assets/d164c95c-f7bd-4e90-a7a6-fb40c9703606)

Error 2

![Image](https://github.com/user-attachments/assets/d13fc0c9-e5d3-4fba-b115-9c3eeadeae09)
