### PR TITLE
implemented some fixes for individual chapters conversion

### DIFF
--- a/UI/src/pages/ProjectsDetail.tsx
+++ b/UI/src/pages/ProjectsDetail.tsx
@@ -459,6 +459,15 @@ const ProjectDetailsPage: React.FC<{ projectId: number }> = ({ projectId }) => {
 
 
   const openChapterModal = (chapter: Chapter, book: Book) => {
+    const isConvertProcessing = sessionStorage.getItem("ConvertingBook");
+    if (isConvertProcessing) {
+      const convertProcessingObj = JSON.parse(isConvertProcessing);
+      toast({
+        variant: "destructive",
+        title: `A book in ${convertProcessingObj.projectName} is currently being converted. Please wait until the conversion is complete.`,
+      });
+      return;
+    }
     if (
       [
         "transcribed",
@@ -935,6 +944,7 @@ const ProjectDetailsPage: React.FC<{ projectId: number }> = ({ projectId }) => {
                               ) {
                                 return;
                               }
+                              sessionStorage.setItem('ConvertingBook', JSON.stringify({ "projectName": project?.name, "status": "Converting"  }));
                               handleTranscribe(book.book_id, selectedChapters);
                             }}
                           >

--- a/UI/src/store/useAuthStore.ts
+++ b/UI/src/store/useAuthStore.ts
@@ -1,6 +1,7 @@
 import { QueryClient } from "@tanstack/react-query";
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
+import { useTranscriptionTrackingStore } from "./useProjectStore";
 
 const BASE_URL = import.meta.env.VITE_BASE_URL;
 
@@ -70,7 +71,6 @@ const useAuthStore = create<AuthState>()(
         }
       },
 
-
       signup: async (username, email, password) => {
         try {
           const response = await fetch(
@@ -116,13 +116,18 @@ const useAuthStore = create<AuthState>()(
           if (!response.ok) {
             throw new Error("Logout failed");
           }
-
+          localStorage.removeItem("active_transcriptions");
+          sessionStorage.removeItem("ConvertingBook");
+          useTranscriptionTrackingStore.getState().clear();
+          if (window.activePollingTimeouts) {
+            window.activePollingTimeouts.forEach(clearTimeout);
+            window.activePollingTimeouts = [];
+          }
           set({ user: null, token: null });
           if (queryClient) {
             queryClient.clear();
             queryClient.removeQueries({ queryKey: ["projects"] });
           }
-          sessionStorage.removeItem('ConvertingBook');
         } catch (error) {
           set({ error: "Failed to log out" });
           throw error;

--- a/UI/src/store/useAuthStore.ts
+++ b/UI/src/store/useAuthStore.ts
@@ -122,6 +122,7 @@ const useAuthStore = create<AuthState>()(
             queryClient.clear();
             queryClient.removeQueries({ queryKey: ["projects"] });
           }
+          sessionStorage.removeItem('ConvertingBook');
         } catch (error) {
           set({ error: "Failed to log out" });
           throw error;

--- a/UI/src/store/useProjectStore.ts
+++ b/UI/src/store/useProjectStore.ts
@@ -4,6 +4,17 @@ import useAuthStore from "./useAuthStore";
 
 const BASE_URL = import.meta.env.VITE_BASE_URL;
 
+declare global {
+  interface Window {
+    activePollingTimeouts: number[];
+  }
+}
+
+if (!window.activePollingTimeouts) {
+  window.activePollingTimeouts = [];
+}
+
+
 interface ProjectDetailsState {
   project: Project | null;
   isLoading: boolean;
@@ -11,7 +22,11 @@ interface ProjectDetailsState {
   setProject: (updater: (project: Project | null) => Project | null) => void;
   fetchProjectDetails: (projectId: number) => void;
   clearProjectState: () => void;
-  transcribeBook: (bookId: number, selectedChapters: any, queryClient?: QueryClient) => Promise<void>;
+  transcribeBook: (
+    bookId: number,
+    selectedChapters: any,
+    queryClient?: QueryClient
+  ) => Promise<void>;
   archiveProject: (projectId: number, archive: boolean) => Promise<void>;
 }
 
@@ -91,6 +106,7 @@ interface TranscriptionTrackingState {
     bookId: number,
     chapterId: number
   ) => void;
+  clear: () => void;
 }
 
 const TRANSCRIPTION_STORAGE_KEY = "active_transcriptions";
@@ -139,23 +155,105 @@ interface ChapterDetailsState {
 // Utility function to calculate book status based on chapters
 const calculateBookStatus = (chapters: Chapter[]): string => {
   console.log("chapters for book status", chapters);
-  if (chapters.every(ch => ch.status === "approved" || ch.approved)) return "approved";
-  if (chapters.every(ch => ["approved", "converted"].includes(ch.status || ""))) return "converted";
-  if (chapters.some(ch => ch.status === "converting")) return "converting";
-  if (chapters.some(ch => ch.status === "inProgress" || ch.progress === "processing")) return "inProgress";
-  if (chapters.every(ch => ["transcribed", "approved", "converted", "modified"].includes(ch.status || ""))) return "transcribed";
-  if (chapters.some(ch => ["error", "transcriptionError", "conversionError"].includes(ch.status || ""))) {
-    if(chapters.length === 1){
+  if (chapters.every((ch) => ch.status === "approved" || ch.approved))
+    return "approved";
+  if (
+    chapters.every((ch) => ["approved", "converted"].includes(ch.status || ""))
+  )
+    return "converted";
+  if (chapters.some((ch) => ch.status === "converting")) return "converting";
+  if (
+    chapters.some(
+      (ch) => ch.status === "inProgress" || ch.progress === "processing"
+    )
+  )
+    return "inProgress";
+  if (
+    chapters.every((ch) =>
+      ["transcribed", "approved", "converted", "modified"].includes(
+        ch.status || ""
+      )
+    )
+  )
+    return "transcribed";
+  if (
+    chapters.some((ch) =>
+      ["error", "transcriptionError", "conversionError"].includes(
+        ch.status || ""
+      )
+    )
+  ) {
+    if (chapters.length === 1) {
       const progress = chapters[0]?.progress || "";
       const status = chapters[0]?.status || "";
-      if (progress.includes("Conversion failed") || status === "conversionError") return "transcribed";
-      if (progress === "Transcription failed" || status === "transcriptionError") return "error";
+      if (
+        progress.includes("Conversion failed") ||
+        status === "conversionError"
+      )
+        return "transcribed";
+      if (
+        progress === "Transcription failed" ||
+        status === "transcriptionError"
+      )
+        return "error";
     }
-    if(chapters.every(ch => ["notTranscribed", "transcribed", "approved", "modified", "converted", "conversionError", "transcriptionError"].includes(ch.status || "") && ch.progress === "Transcription failed")) return "transcriptionError";
-    if(chapters.every(ch => ["transcribed", "approved", "modified", "converted", "transcriptionError"].includes(ch.status || "") && ch.progress === "")) return "error";
-    if(chapters.every(ch => ["transcribed", "approved", "modified", "converted", "conversionError"].includes(ch.status || ""))) return "transcribed";
-    if(chapters.every(ch => ["transcribed", "approved", "modified", "converted", "conversionError", "transcriptionError"].includes(ch.status || "") && ["Conversion failed", ""].includes(ch.progress || ""))) return "conversionError";
-    if(chapters.some(ch => ch.progress === "Failed to fetch chapter status")) return "apiError";
+    if (
+      chapters.every(
+        (ch) =>
+          [
+            "notTranscribed",
+            "transcribed",
+            "approved",
+            "modified",
+            "converted",
+            "conversionError",
+            "transcriptionError",
+          ].includes(ch.status || "") && ch.progress === "Transcription failed"
+      )
+    )
+      return "transcriptionError";
+    if (
+      chapters.every(
+        (ch) =>
+          [
+            "transcribed",
+            "approved",
+            "modified",
+            "converted",
+            "transcriptionError",
+          ].includes(ch.status || "") && ch.progress === ""
+      )
+    )
+      return "error";
+    if (
+      chapters.every((ch) =>
+        [
+          "transcribed",
+          "approved",
+          "modified",
+          "converted",
+          "conversionError",
+        ].includes(ch.status || "")
+      )
+    )
+      return "transcribed";
+    if (
+      chapters.every(
+        (ch) =>
+          [
+            "transcribed",
+            "approved",
+            "modified",
+            "converted",
+            "conversionError",
+            "transcriptionError",
+          ].includes(ch.status || "") &&
+          ["Conversion failed", ""].includes(ch.progress || "")
+      )
+    )
+      return "conversionError";
+    if (chapters.some((ch) => ch.progress === "Failed to fetch chapter status"))
+      return "apiError";
 
     return "error";
   }
@@ -169,11 +267,16 @@ const updateChapterStatus = (
   isInProgress: boolean = false
 ): string => {
   if (isApproved) return "approved";
-  
-  const allTranscribed = verses.length > 0 && verses.every(verse => verse.stt);
-  const modifiedVerses = verses.filter(verse => verse.modified);
-  const allModifiedConverted = modifiedVerses.length > 0 && allTranscribed && modifiedVerses.every(verse => verse.tts && verse.stt);
-  const checkChapterOnlyModified = modifiedVerses.length > 0 && allTranscribed && !allModifiedConverted;
+
+  const allTranscribed =
+    verses.length > 0 && verses.every((verse) => verse.stt);
+  const modifiedVerses = verses.filter((verse) => verse.modified);
+  const allModifiedConverted =
+    modifiedVerses.length > 0 &&
+    allTranscribed &&
+    modifiedVerses.every((verse) => verse.tts && verse.stt);
+  const checkChapterOnlyModified =
+    modifiedVerses.length > 0 && allTranscribed && !allModifiedConverted;
   if (allModifiedConverted) return "converted";
   if (checkChapterOnlyModified) return "modified";
   if (allTranscribed) return "transcribed";
@@ -333,6 +436,7 @@ export const useTranscriptionTrackingStore = create<TranscriptionTrackingState>(
         return state;
       });
     },
+    clear: () => set({ activeTranscriptions: {} }),
   })
 );
 
@@ -362,12 +466,12 @@ export const useProjectDetailsStore = create<ProjectDetailsState>(
           }
         );
         const data = await response.json();
-        if(!response.ok){
+        if (!response.ok) {
           throw new Error(data.detail || "Failed to fetch project details");
         }
 
         useTranscriptionTrackingStore.getState().clearStaleTranscriptions();
-        const projectData = data.projects[0]
+        const projectData = data.projects[0];
         // Fetch detailed status for each book and chapter
         const updatedBooks = await Promise.all(
           projectData.books.map(async (book: Book) => {
@@ -397,8 +501,11 @@ export const useProjectDetailsStore = create<ProjectDetailsState>(
                   const chapterStatusData: ChapterStatusResponse =
                     await chapterStatusResponse.json();
 
-                  if(!chapterStatusResponse.ok){
-                    throw new Error(chapterStatusData.detail || "Failed to fetch chapter status");
+                  if (!chapterStatusResponse.ok) {
+                    throw new Error(
+                      chapterStatusData.detail ||
+                        "Failed to fetch chapter status"
+                    );
                   }
 
                   const verses = chapterStatusData.data;
@@ -423,7 +530,10 @@ export const useProjectDetailsStore = create<ProjectDetailsState>(
                   return {
                     ...chapter,
                     status,
-                    progress: status === "inProgress" ? `${completed} out of ${total} done` : "",
+                    progress:
+                      status === "inProgress"
+                        ? `${completed} out of ${total} done`
+                        : "",
                     verses: verses,
                   };
                 } catch (error) {
@@ -466,7 +576,11 @@ export const useProjectDetailsStore = create<ProjectDetailsState>(
 
     clearProjectState: () => set({ project: null }),
 
-    transcribeBook: async (bookId: number, selectedChapters: Chapter[], queryClient?: QueryClient) => {
+    transcribeBook: async (
+      bookId: number,
+      selectedChapters: Chapter[],
+      queryClient?: QueryClient
+    ) => {
       const token = useAuthStore.getState().token;
       const currentProject = get().project;
 
@@ -479,7 +593,7 @@ export const useProjectDetailsStore = create<ProjectDetailsState>(
         if (!book) throw new Error("Book not found");
         let hasErrors = false;
         let totalChaptersProcessed = 0;
-        
+
         const updateChapterStatusInState = (
           chapterId: number,
           status: string,
@@ -492,7 +606,7 @@ export const useProjectDetailsStore = create<ProjectDetailsState>(
               if (b.book_id === bookId && b?.chapters.length) {
                 const updatedChapters = b.chapters.map((ch) => {
                   if (ch.chapter_id === chapterId) {
-                    const isApproved = ch.approved
+                    const isApproved = ch.approved;
                     return {
                       ...ch,
                       status: isApproved ? "approved" : status,
@@ -506,9 +620,9 @@ export const useProjectDetailsStore = create<ProjectDetailsState>(
                   ...b,
                   chapters: updatedChapters,
                   status: calculateBookStatus(updatedChapters),
-                  progress: updatedChapters.find(
-                    (ch) => ch.chapter_id === chapterId
-                  )?.progress || "processing",
+                  progress:
+                    updatedChapters.find((ch) => ch.chapter_id === chapterId)
+                      ?.progress || "processing",
                 };
               }
               return b;
@@ -552,6 +666,11 @@ export const useProjectDetailsStore = create<ProjectDetailsState>(
             }
             await new Promise<void>((resolve, reject) => {
               const pollChapterStatus = async () => {
+                if (!useAuthStore.getState().token) {
+                  console.log("User is logged out. Aborting polling.");
+                  reject(new Error("User logged out during polling"));
+                  return;
+                }
                 try {
                   // Update timestamp for current chapter
                   useTranscriptionTrackingStore
@@ -586,14 +705,21 @@ export const useProjectDetailsStore = create<ProjectDetailsState>(
 
                   if (hasTranscriptionError || allTranscribed) {
                     totalChaptersProcessed++;
-                    if (hasTranscriptionError){
-                    hasErrors = true;
-                    updateChapterStatusInState(chapter.chapter_id, "transcriptionError", "Transcription failed");
+                    if (hasTranscriptionError) {
+                      hasErrors = true;
+                      updateChapterStatusInState(
+                        chapter.chapter_id,
+                        "transcriptionError",
+                        "Transcription failed"
+                      );
+                    } else {
+                      updateChapterStatusInState(
+                        chapter.chapter_id,
+                        "transcribed",
+                        ""
+                      );
                     }
-                    else{
-                      updateChapterStatusInState(chapter.chapter_id, "transcribed", "");
-                    }
-                      
+
                     console.log(
                       `Chapter processed: ${chapter.chapter}, Total processed: ${totalChaptersProcessed}`
                     );
@@ -611,8 +737,11 @@ export const useProjectDetailsStore = create<ProjectDetailsState>(
                       chapter.chapter_id,
                       "inProgress",
                       `${completed} out of ${total} done`
-                    )
-                    setTimeout(pollChapterStatus, 5000);
+                    );
+                    const timeoutId = setTimeout(pollChapterStatus, 5000) as unknown as number;
+                    window.activePollingTimeouts =
+                      window.activePollingTimeouts || [];
+                    window.activePollingTimeouts.push(timeoutId);
                   }
                 } catch (error) {
                   totalChaptersProcessed++;
@@ -625,7 +754,11 @@ export const useProjectDetailsStore = create<ProjectDetailsState>(
           } catch (error) {
             // Update state with error status
             hasErrors = true;
-            updateChapterStatusInState(chapter.chapter_id, "transcriptionError", "Transcription failed");
+            updateChapterStatusInState(
+              chapter.chapter_id,
+              "transcriptionError",
+              "Transcription failed"
+            );
             // Remove progress tracking for failed chapter
             useTranscriptionTrackingStore
               .getState()
@@ -643,7 +776,9 @@ export const useProjectDetailsStore = create<ProjectDetailsState>(
 
           const updatedBooks = state.project.books.map((b) => {
             if (b.book_id === bookId && b?.chapters.length) {
-              const bookStatus = hasErrors ? "error" : calculateBookStatus(b.chapters);
+              const bookStatus = hasErrors
+                ? "error"
+                : calculateBookStatus(b.chapters);
               return { ...b, status: bookStatus, progress: "" };
             }
             return b;
@@ -663,7 +798,7 @@ export const useProjectDetailsStore = create<ProjectDetailsState>(
         set({ error: "Error transcribing book", isLoading: false });
         throw error;
       }
-      sessionStorage.removeItem('ConvertingBook');
+      sessionStorage.removeItem("ConvertingBook");
     },
 
     archiveProject: async (projectId, archive) => {
@@ -729,7 +864,7 @@ export const useChapterDetailsStore = create<ChapterDetailsState>((set) => ({
         }
       );
       const data = await response.json();
-      if(!response.ok){
+      if (!response.ok) {
         throw new Error(data?.detail || "Failed to fetch chapter details");
       }
       set((state) => ({
@@ -787,7 +922,7 @@ export const useChapterDetailsStore = create<ChapterDetailsState>((set) => ({
           });
           return { ...prevProject, books: updatedBooks };
         });
-      }else{
+      } else {
         throw new Error("Failed to update verse");
       }
     } catch (error) {
@@ -810,59 +945,62 @@ export const useChapterDetailsStore = create<ChapterDetailsState>((set) => ({
       const chapterDetails = await useChapterDetailsStore
         .getState()
         .fetchChapterDetails(projectId, book, chapter);
-   
 
-        if (response.ok && chapterDetails && chapterDetails.length > 0) {
-          const checkTranscribed = chapterDetails.every((verse) => verse.stt);
-          const modifiedVerses = chapterDetails.filter((verse) => verse.modified);
-          const checkModifiedConverted =
-            modifiedVerses.length > 0 &&
-            modifiedVerses.every((verse) => verse.tts);
-          const checkChapterOnlyModified = modifiedVerses.length >0 && !checkModifiedConverted;
-          useProjectDetailsStore.getState().setProject((prevProject) => {
-            if (!prevProject) return null;
-  
-            const updatedBooks = prevProject.books.map((b) => {
-              if (b.book === book && b.chapters?.length) {
-                const updatedChapters = b.chapters.map((ch) => {
-                  if (ch.chapter === chapter) {
-                    const newStatus = approve
-                      ? "approved"
-                      : checkModifiedConverted
-                      ? "converted"
-                      : checkChapterOnlyModified ? "modified" 
-                      : checkTranscribed
-                      ? "transcribed"
-                      : ch.status;
-                    return {
-                      ...ch,
-                      approved: approve,
-                      status: newStatus,
-                    };
-                  }
-                  return ch;
-                });
-  
-                const updatedBookStatus = calculateBookStatus(updatedChapters);
-                
-                return {
-                  ...b,
-                  chapters: updatedChapters,
-                  status: updatedBookStatus,
-                  approved: updatedChapters.length > 0 && updatedChapters.every((ch) => ch.approved),
-                };
-              }
-              return b;
-            });
-  
-            return {
-              ...prevProject,
-              books: updatedBooks,
-            };
+      if (response.ok && chapterDetails && chapterDetails.length > 0) {
+        const checkTranscribed = chapterDetails.every((verse) => verse.stt);
+        const modifiedVerses = chapterDetails.filter((verse) => verse.modified);
+        const checkModifiedConverted =
+          modifiedVerses.length > 0 &&
+          modifiedVerses.every((verse) => verse.tts);
+        const checkChapterOnlyModified =
+          modifiedVerses.length > 0 && !checkModifiedConverted;
+        useProjectDetailsStore.getState().setProject((prevProject) => {
+          if (!prevProject) return null;
+
+          const updatedBooks = prevProject.books.map((b) => {
+            if (b.book === book && b.chapters?.length) {
+              const updatedChapters = b.chapters.map((ch) => {
+                if (ch.chapter === chapter) {
+                  const newStatus = approve
+                    ? "approved"
+                    : checkModifiedConverted
+                    ? "converted"
+                    : checkChapterOnlyModified
+                    ? "modified"
+                    : checkTranscribed
+                    ? "transcribed"
+                    : ch.status;
+                  return {
+                    ...ch,
+                    approved: approve,
+                    status: newStatus,
+                  };
+                }
+                return ch;
+              });
+
+              const updatedBookStatus = calculateBookStatus(updatedChapters);
+
+              return {
+                ...b,
+                chapters: updatedChapters,
+                status: updatedBookStatus,
+                approved:
+                  updatedChapters.length > 0 &&
+                  updatedChapters.every((ch) => ch.approved),
+              };
+            }
+            return b;
           });
-        }else{
-          const errorResp = await response.json();
-          throw new Error(errorResp.detail || "Failed to approve chapter");
+
+          return {
+            ...prevProject,
+            books: updatedBooks,
+          };
+        });
+      } else {
+        const errorResp = await response.json();
+        throw new Error(errorResp.detail || "Failed to approve chapter");
       }
     } catch (error) {
       console.error("Failed to approve chapter:", error);
@@ -899,9 +1037,10 @@ export const useChapterDetailsStore = create<ChapterDetailsState>((set) => ({
               ...b,
               chapters: updatedChapters,
               status: updatedBookStatus,
-              progress: updatedChapters.find(
-                (ch) => ch.chapter_id === chapter.chapter_id
-              )?.progress || "",
+              progress:
+                updatedChapters.find(
+                  (ch) => ch.chapter_id === chapter.chapter_id
+                )?.progress || "",
             };
           }
           return b;
@@ -923,9 +1062,11 @@ export const useChapterDetailsStore = create<ChapterDetailsState>((set) => ({
     try {
       // check for chapter details
       const fetchAndUpdateChapter = async (): Promise<Verse[] | null> => {
-        return useChapterDetailsStore
-          .getState()
-          .fetchChapterDetails(project_id, bookName, chapter.chapter) || [];
+        return (
+          useChapterDetailsStore
+            .getState()
+            .fetchChapterDetails(project_id, bookName, chapter.chapter) || []
+        );
       };
 
       const chapterDetails = await fetchAndUpdateChapter();
@@ -975,15 +1116,22 @@ export const useChapterDetailsStore = create<ChapterDetailsState>((set) => ({
             );
 
             //check for any TTS errors
-            const failedVerse = modifiedVerses.find(verse => verse.tts_msg && verse.tts_msg !== "Text-to-speech completed");
+            const failedVerse = modifiedVerses.find(
+              (verse) =>
+                verse.tts_msg && verse.tts_msg !== "Text-to-speech completed"
+            );
 
-            if(failedVerse){
-              updateChapterStatus("conversionError", "Conversion failed", details);
+            if (failedVerse) {
+              updateChapterStatus(
+                "conversionError",
+                "Conversion failed",
+                details
+              );
               reject(failedVerse.tts_msg || "Conversion failed");
               return;
             }
 
-            if(completedModifiedVerses.length === modifiedVerses.length){
+            if (completedModifiedVerses.length === modifiedVerses.length) {
               await useChapterDetailsStore
                 .getState()
                 .fetchChapterDetails(project_id, bookName, chapter.chapter);
@@ -991,10 +1139,12 @@ export const useChapterDetailsStore = create<ChapterDetailsState>((set) => ({
               updateChapterStatus("converted", "", details);
 
               resolve("Text-to-speech conversion completed successfully");
-            }else{
+            } else {
               //Still converting
               updateChapterStatus("converting", "Converting", details);
-              setTimeout(pollTTSStatus, 5000);
+              const timeoutId = setTimeout(pollTTSStatus, 5000) as unknown as number;
+              window.activePollingTimeouts.push(timeoutId);
+
             }
           } catch (error) {
             updateChapterStatus("conversionError", "Conversion failed");

--- a/UI/src/store/useProjectStore.ts
+++ b/UI/src/store/useProjectStore.ts
@@ -11,7 +11,7 @@ interface ProjectDetailsState {
   setProject: (updater: (project: Project | null) => Project | null) => void;
   fetchProjectDetails: (projectId: number) => void;
   clearProjectState: () => void;
-  transcribeBook: (bookId: number, queryClient?: QueryClient) => Promise<void>;
+  transcribeBook: (bookId: number, selectedChapters: any, queryClient?: QueryClient) => Promise<void>;
   archiveProject: (projectId: number, archive: boolean) => Promise<void>;
 }
 
@@ -466,7 +466,7 @@ export const useProjectDetailsStore = create<ProjectDetailsState>(
 
     clearProjectState: () => set({ project: null }),
 
-    transcribeBook: async (bookId: number, queryClient?: QueryClient) => {
+    transcribeBook: async (bookId: number, selectedChapters: Chapter[], queryClient?: QueryClient) => {
       const token = useAuthStore.getState().token;
       const currentProject = get().project;
 
@@ -524,7 +524,8 @@ export const useProjectDetailsStore = create<ProjectDetailsState>(
         };
 
         // Sequential chapter transcription
-        for (const chapter of book.chapters) {
+        // for (const chapter of book.chapters) {  --> removing for now for adding chapter wise convertion
+        for (const chapter of selectedChapters) {
           // Set progress for current chapter
           useTranscriptionTrackingStore
             .getState()

--- a/UI/src/store/useProjectStore.ts
+++ b/UI/src/store/useProjectStore.ts
@@ -663,6 +663,7 @@ export const useProjectDetailsStore = create<ProjectDetailsState>(
         set({ error: "Error transcribing book", isLoading: false });
         throw error;
       }
+      sessionStorage.removeItem('ConvertingBook');
     },
 
     archiveProject: async (projectId, archive) => {


### PR DESCRIPTION
- #175 

- Implemented killing the polling chapter api call when user does a log out operation during an active transcription process.
- retain the selected chapters state in storage so that when user comes back to same project, it should show selected chapters in UI. 
- Allow opening the modal if chapter is already transcribed, modified, converted or approved rather preventing to open the modal if other chapter transcription is in progress.

@Joel-C-Johnson @RevantCI 